### PR TITLE
Add blank icon option

### DIFF
--- a/fontawesome/fields.py
+++ b/fontawesome/fields.py
@@ -11,6 +11,7 @@ class IconField(models.Field):
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 60
+        kwargs['blank'] = True
         super(IconField, self).__init__(*args, **kwargs)
 
     def get_internal_type(self):

--- a/fontawesome/utils.py
+++ b/fontawesome/utils.py
@@ -5,7 +5,7 @@ PATH = os.path.join(os.path.dirname(__file__), 'icons.yml')
 
 def get_icon_choices():
 
-    CHOICES = []
+    CHOICES = [('', '----------')]
 
     with open(PATH) as f:
         icons = yaml.load(f)


### PR DESCRIPTION
Add a blank option the form widget for situations where there isn't a relevant FontAwesome icon.
