### PR TITLE
Support for IconField in django admin inlines for related model

### DIFF
--- a/fontawesome/fields.py
+++ b/fontawesome/fields.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.utils.translation import ugettext as _
 
 from . import Icon
-from forms import IconFormField
+from .forms import IconFormField
 
 class IconField(models.Field):
 

--- a/fontawesome/forms.py
+++ b/fontawesome/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 
 from . import Icon
-from widgets import IconWidget
+from .widgets import IconWidget
 
 class IconFormField(forms.Field):
 

--- a/fontawesome/static/fontawesome/js/django_fontawesome.js
+++ b/fontawesome/static/fontawesome/js/django_fontawesome.js
@@ -13,11 +13,46 @@ $(function() {
         return '<i class="' + prefix + ' ' + prefix + '-' + icon + '"></i> ' + state.text;
     }
 
+    var endsWith = function(value, suffix){
+        return value.indexOf(suffix, value.length - suffix.length) !== -1;    
+    };
+    
+    var install  = function(){
+        $('.fontawesome-select').each(function(){
+                
+            if ($(this).data('select2')){
+                // Already installed - nothing to do
+                return;
+            }
+            
+            var id = $(this).parents('.empty-form ').attr('id');
+            if( id != null){
 
-    $('.fontawesome-select').select2({
-        width:'element',
-        formatResult:format,
-        formatSelection:format,
-        escapeMarkup: function(m) {return m;}
+                // Inline formsets contains a template for the select with '-empty' suffix in the id.
+                // We do not want to install select2 on the template, as clicking '.add-row a' calls clone which will break the select2
+                var suffix = "-empty";
+                var isEmptyTemplate = endsWith(id, "-empty");
+                
+                if(isEmptyTemplate){
+                    return;
+                }
+            }            
+            
+            $(this).select2({
+                width:'element',
+                formatResult:format,
+                formatSelection:format,
+                escapeMarkup: function(m) {return m;}
+            });
+            
+        });
+    }
+
+    //Install on regular fields of the form
+    install();
+    
+    // Install on dynamically created inline items
+    $('.inline-group .add-row a').click(function(){
+            install();
     });
 });

--- a/fontawesome/widgets.py
+++ b/fontawesome/widgets.py
@@ -4,7 +4,7 @@ from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.html import format_html
 
-from utils import get_icon_choices
+from .utils import get_icon_choices
 
 CHOICES = get_icon_choices()
 


### PR DESCRIPTION
When you have a `IconField` on a model which is used with djangos `StackedInline` or `TabularInline` django-fontawesome won't work on items created with "add new" button. This happens because select2 is applied to all tags with `.fontawesome-select`, event the template ones used by django when cloning form for inline related model.

I modified the js code so that it skips installation of select2 for the template tags, and added installation of select2 after `add-row` button is pressed.
