### PR TITLE
Use `yaml.safe_load` (instead of unsafe yaml.load)

### DIFF
--- a/fontawesome/utils.py
+++ b/fontawesome/utils.py
@@ -8,7 +8,7 @@ def get_icon_choices():
     CHOICES = [('', '----------')]
 
     with open(PATH) as f:
-        icons = yaml.load(f)
+        icons = yaml.safe_load(f)
 
     for icon in icons.get('icons'):
         CHOICES.append((


### PR DESCRIPTION
Using the `load()` method is inherently unsafe, because the content gets executed. The PyYAML documentation [warns about that](http://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML) and suggests using `safe_load()` instead.