### PR TITLE
Make the plugin font icon agnostic

### DIFF
--- a/fontawesome/__init__.py
+++ b/fontawesome/__init__.py
@@ -10,8 +10,8 @@ class Icon(object):
         if not self.id:
             return ''
 
-        prefix = getattr(settings, 'FONTAWESOME_PREFIX', 'fa')
-        return format_html('<i class="{0} {0}-{1}"></i>', prefix, self.id)
+        prefix = getattr(settings, 'FONTAWESOME_PREFIX', '-fa')
+        return format_html('<i class="{0} {0}{1}"></i>', prefix, self.id)
 
     def __str__(self):
         return self.id

--- a/fontawesome/forms.py
+++ b/fontawesome/forms.py
@@ -21,8 +21,10 @@ class IconFormField(forms.Field):
         classes.append('fontawesome-select')
 
         fontawesome_prefix = getattr(settings, 'FONTAWESOME_PREFIX', 'fa')
+        fontawesome_prefix_icon = getattr(settings, 'FONTAWESOME_PREFIX_ICON', 'fa-')
 
         return {
             'class': ' '.join(classes),
-            'data-fontawesome-prefix':fontawesome_prefix
+            'data-fontawesome-prefix':fontawesome_prefix,
+            'data-fontawesome-prefix-icon':fontawesome_prefix_icon
         }

--- a/fontawesome/static/fontawesome/js/django_fontawesome.js
+++ b/fontawesome/static/fontawesome/js/django_fontawesome.js
@@ -6,11 +6,12 @@ if (!$) {
 $(function() {
 
     var prefix = $('select.fontawesome-select').data('fontawesome-prefix');
+    var prefix_icon = $('select.fontawesome-select').data('fontawesome-prefix-icon');
 
     function format(state) {
         if (!state.id) { return state.text; }
         var icon = $(state.element).data('icon');
-        return '<i class="' + prefix + ' ' + prefix + icon + '"></i> ' + state.text;
+        return '<i class="' + prefix + ' ' + prefix_icon + icon + '"></i> ' + state.text;
     }
 
     var endsWith = function(value, suffix){

--- a/fontawesome/static/fontawesome/js/django_fontawesome.js
+++ b/fontawesome/static/fontawesome/js/django_fontawesome.js
@@ -10,7 +10,7 @@ $(function() {
     function format(state) {
         if (!state.id) { return state.text; }
         var icon = $(state.element).data('icon');
-        return '<i class="' + prefix + ' ' + prefix + '-' + icon + '"></i> ' + state.text;
+        return '<i class="' + prefix + ' ' + prefix + icon + '"></i> ' + state.text;
     }
 
     var endsWith = function(value, suffix){

--- a/fontawesome/widgets.py
+++ b/fontawesome/widgets.py
@@ -17,7 +17,6 @@ if hasattr(settings, 'FONTAWESOME_ICON_CHOICE'):
         CHOICES = import_string(choices_settings)()
         
     except Exception as e:
-        print(e)
         CHOICES = choices_settings
 
 else :

--- a/fontawesome/widgets.py
+++ b/fontawesome/widgets.py
@@ -6,10 +6,22 @@ from django.conf import settings
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.html import format_html
+from django.utils.module_loading import import_string
 
 from .utils import get_icon_choices
 
-CHOICES = get_icon_choices()
+# Check if settings FONTAWESOME_ICON_CHOICE is set
+if hasattr(settings, 'FONTAWESOME_ICON_CHOICE'):
+    choices_settings = settings.FONTAWESOME_ICON_CHOICE
+    try : # If path to function
+        CHOICES = import_string(choices_settings)()
+        
+    except Exception as e:
+        print(e)
+        CHOICES = choices_settings
+
+else :
+    CHOICES = get_icon_choices()
 
 class IconWidget(forms.Select):
 


### PR DESCRIPTION
The purpose of this pull request is to make the plugin font icon agnostic, which tenfold its usefulness :) 
Also people could create their own collection of icons if needed

I'm not sure it's enough but I wanted to see if you would be interested in it.
The idea is that we could use other fonts ( and even custom ones ) instead of FA.

Mostly the function to fetch the icons is now a settings ( or yours if none ).

```
FONTAWESOME_CSS_URL = '/static/scss/icon-font.css'  # relative url
FONTAWESOME_ICON_CHOICE = "path.to.function" # Should return a tuple [('icon-teacher', 'Teacher')]
FONTAWESOME_PREFIX = 'icon '  # default is 'fa'
FONTAWESOME_PREFIX_ICON = ''  # default is 'fa-'
```
Below is an exemple of what those 3 settings produce

<img width="394" alt="capture d ecran 2018-06-12 a 22 17 11" src="https://user-images.githubusercontent.com/22885020/41314947-74a9dd36-6e8e-11e8-9420-88d0fb2654ca.png">
