### PR TITLE
Update staticfiles import

### DIFF
--- a/fontawesome/templatetags/fontawesome.py
+++ b/fontawesome/templatetags/fontawesome.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django import template
 from django.conf import settings
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.utils.html import format_html, mark_safe
 
 register = template.Library()


### PR DESCRIPTION
django.contrib.staticfiles.templatetags was deprecated in Django 2.1 and completely removed in Django 3.